### PR TITLE
fix: UnboundLocalError: local variable 'fullpath' referenced before a…

### DIFF
--- a/guietta/guietta.py
+++ b/guietta/guietta.py
@@ -447,6 +447,8 @@ def _image_fullpath(gui, filename):
 
     if not os.path.isabs(filename):
         fullpath = os.path.join(gui.images_dir, filename)
+    else:
+        fullpath = filename
 
     name, _ = os.path.splitext(filename)
 


### PR DESCRIPTION
…… (#4)

* fix: UnboundLocalError: local variable 'fullpath' referenced before assignment


Co-authored-by: Anvesh Dindu <anvesh.dindu@qvantel.com>